### PR TITLE
hide wordpress integration guide. it doesn't work yet

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -6,7 +6,6 @@ sidebar_position: 1
 # How to
 
 - [Sending Enrollment Emails](/guides/send-enrollment)
-- [Integrate with Wordpress](/guides/integrate-wordpress)
 - [Integrate Auth into a bubble.io application](/guides/bubble-io-integration.md)
 
 # Integration with other SSOs


### PR DESCRIPTION
hide wordpress integration guide. it doesn't work yet. 

Do not change the actual source files, so we can re-add it later.