### PR TITLE
[Flutter] Specify minimum deployment target in documentation for iOS

### DIFF
--- a/docs/sdks/flutter-sdk/overview.md
+++ b/docs/sdks/flutter-sdk/overview.md
@@ -24,6 +24,26 @@ dependencies:
 
 and run an implicit `flutter pub get`.
 
+### Update Android
+
+Please make sure your `android/build.gradle` supports `minSdkVersion` 26 or later.
+
+```
+buildscript {
+  ext {
+    minSdkVersion = 26
+  }
+}
+```
+
+### Update iOS
+
+Please make sure your project supports "minimum deployment target" 13.0 or later.
+
+```
+IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+```
+
 ## Setup
 
 First, before calling the Embedded functions, make sure to initialize the SDK.


### PR DESCRIPTION
The default app generated when creating a flutter project sets the iOS minimum deployment target to 11.0 which causes compilation to fail. I randomly bumped this up to 13.0 and it started working again. We should figure out the minimum deployment target we support and specify that in:

- Developer Docs

- Github Readme