### PR TITLE
Capitalize Universal Passkey throughout docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,7 +3,7 @@ title: Introduction
 sidebar_position: 1
 ---
 
-Welcome to the developer documentation for Beyond Identity. This is where you can find guides for building authentication across your applications using universal passkeys. 
+Welcome to the developer documentation for Beyond Identity. This is where you can find guides for building authentication across your applications using Universal Passkeys. 
 
 If you run into any issues or have feedback for us along the way, you can let us know by **[joining our Slack community](https://join.slack.com/t/byndid/shared_invite/zt-1anns8n83-NQX4JvW7coi9dksADxgeBQ)**.
 
@@ -37,7 +37,7 @@ While we’re not the first to solve the problem with asymmetric cryptography, t
 
 
 ## How it Works
-Beyond Identity allows developers to implement strong authentication from multiple devices based on public-private key pairs (what we call universal passkeys). All keys are cryptographically linked to the user and can be centrally managed using our APIs.
+Beyond Identity allows developers to implement strong authentication from multiple devices based on public-private key pairs (what we call Universal Passkeys). All keys are cryptographically linked to the user and can be centrally managed using our APIs.
 
 Instead of shared secrets, Beyond Identity authenticates customers with two strong factors -- "something you are" from the device biometric and "something you own" from the private key -- without requiring a second device.
 

--- a/docs/platform-overview/passkeys-and-devices/what-are-passkeys.md
+++ b/docs/platform-overview/passkeys-and-devices/what-are-passkeys.md
@@ -1,13 +1,13 @@
 ---
-title: Universal passkeys and devices
+title: Universal Passkeys and devices
 sidebar_position: 1
 ---
 
-## What is a universal Passkey?
+## What is a Universal Passkey?
 
-A universal passkey is a public and private key pair. The private key is generated, stored, and never leaves the user’s devices’ hardware root of trust (i.e. secure enclave). The public key is sent to the Beyond Identity cloud. 
+A Universal Passkey is a public and private key pair. The private key is generated, stored, and never leaves the user’s devices’ hardware root of trust (i.e. secure enclave). The public key is sent to the Beyond Identity cloud. 
 
-Universal passkeys are cryptographically linked to devices and an identity. Universal passkeys are compatible with any device running any OS. 
+Universal Passkeys are cryptographically linked to devices and an identity. Universal Passkeys are compatible with any device running any OS. 
 
 The private key cannot be tampered with, viewed, or removed from the device in which it is created unless the user explicitly indicates that the trusted device be removed. We support multiple passkeys per identity and a single device can store multiple passkeys for different users.
 
@@ -19,7 +19,7 @@ You can use Beyond Identity to prompt for a biometric authentication at sign-up 
 If your application requires identity verification, those requirements should be met before a passkey is created for the identity.
 
 
-### Universal passkey and trusted devices
+### Universal Passkey and trusted devices
 
 A trusted device is a device that a user has authorized to have a passkey that allows them access to your application. The device with which the user enrolls in passkeys is their first trusted device. 
 

--- a/src/pages/try-it-out/index.jsx
+++ b/src/pages/try-it-out/index.jsx
@@ -461,7 +461,7 @@ export default function TryItOut() {
   };
 
   return (
-    <Layout id="try-it-out" title="Try It Out" description="Try out Universal passkeys">
+    <Layout id="try-it-out" title="Try It Out" description="Try out Universal Passkeys">
       <div id="step-one" className={classNames(padding["mt-1"])}>
         <StepOne {...state}></StepOne>
       </div>


### PR DESCRIPTION
From Jing "When it’s standalone, passkeys should be lower case. when it’s in conjunction with Universal, it should be upper case bc it’s part of our branding"