### PR TITLE
Update React Native expo instructions

### DIFF
--- a/docs/workflows/_deeplinking-native-sdk.mdx
+++ b/docs/workflows/_deeplinking-native-sdk.mdx
@@ -25,7 +25,7 @@ Apple supports two ways of deep linking into an application. Pick one of the fol
 
 If you are using Expo, follow the [deep linking guide](https://docs.expo.dev/guides/deep-linking/).
 
-If you are using a `bare expo` or `react-native init` project, follow the Kotlin and Swift guides to setting up deep linking on React Native.
+If you are using an app created with the react native CLI, follow the Kotlin and Swift guides to setting up deep linking on React Native.
 
 Also check out [React Native Linking](https://reactnative.dev/docs/linking):
 

--- a/docs/workflows/_sdk-setup/_installation-react-native-expo.mdx
+++ b/docs/workflows/_sdk-setup/_installation-react-native-expo.mdx
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 ```bash
-expo install @beyondidentity/bi-sdk-react-native
+npx expo install @beyondidentity/bi-sdk-react-native
 ```
 
 Add the SDK [config plugin](https://docs.expo.dev/guides/config-plugins/) to the [plugins array](https://docs.expo.dev/versions/latest/config/app/#plugins) of your app.{json,config.js,config.ts}:
@@ -15,13 +15,10 @@ Add the SDK [config plugin](https://docs.expo.dev/guides/config-plugins/) to the
 }
 ```
 
-The SDK requires certain minimum native versions. You can set these requirments either with another plugin, [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/), or by modifing project [static files](https://docs.expo.dev/guides/config-plugins/#static-modification).
-
-<Tabs groupId="requirements" queryString>
-<TabItem value="expo-build-properties" label="expo-build-properties">
+The SDK requires certain minimum native versions. Set these requirments with [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/).
 
 ```bash
-expo install expo-build-properties
+npx expo install expo-build-properties
 ```
 
 ```json
@@ -45,18 +42,4 @@ expo install expo-build-properties
 }
 ```
 
-</TabItem>
-<TabItem value="static-files" label="static files">
-
-```bash title="android/gradle.properties"
-android.minSdkVersion=26
-```
-
-```bash title="ios/Podfile.properties.json"
-"ios.deploymentTarget": "13.0"
-```
-
-</TabItem>
-</Tabs>
-
-Finally, rebuild your app as described in Expo's [Adding custom native code guide](https://docs.expo.dev/workflow/customizing/).
+Finally, rebuild your app as described in Expo's [Adding custom native code guide](https://docs.expo.dev/workflow/customizing/#generate-native-projects-with-prebuild).

--- a/docs/workflows/_sdk-setup/_installation-react-native.mdx
+++ b/docs/workflows/_sdk-setup/_installation-react-native.mdx
@@ -3,7 +3,7 @@ import BareInstallation from './_installation-react-native-bare.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-### Using [react-native init](https://reactnative.dev/docs/environment-setup) or a [expo](https://docs.expo.dev/get-started/create-a-project/) app.
+### Using [react-native init](https://reactnative.dev/docs/environment-setup) or an [expo](https://docs.expo.dev/get-started/create-a-project/) app.
 
 <Tabs groupId="rn-installation" queryString>
 <TabItem value="bare" label="react-native init">

--- a/docs/workflows/_sdk-setup/_installation-react-native.mdx
+++ b/docs/workflows/_sdk-setup/_installation-react-native.mdx
@@ -3,7 +3,7 @@ import BareInstallation from './_installation-react-native-bare.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-### Using [react-native init](https://reactnative.dev/docs/environment-setup) or a [bare expo](https://docs.expo.dev/bare/hello-world/) app.
+### Using [react-native init](https://reactnative.dev/docs/environment-setup) or a [expo](https://docs.expo.dev/get-started/create-a-project/) app.
 
 <Tabs groupId="rn-installation" queryString>
 <TabItem value="bare" label="react-native init">
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="expo" label="expo">
 
 :::info
-This package cannot be used in "Expo Go" because [it requires custom native code](https://docsexpo.io/workflow/customizing/). However you can leverage this library with a [development build](https://docs.expo.dev/development/introduction/) or [prebuild](https://docs.expo.dev/workflowprebuild/).
+This package [requires custom native code](https://docs.expo.io/workflow/customizing/) and can be used with [Development builds](https://docs.expo.dev/develop/development-builds/introduction/) or  [prebuild](https://docs.expo.dev/workflow/prebuild/) and cannot be used with Expo Go.
 :::
 
 <ExpoInstallation />


### PR DESCRIPTION
Updating the react native documentation based on suggestions by @amandeepmittal in https://github.com/gobeyondidentity/bi-sdk-react-native/pull/1

Tap on [Visit Preview](https://developer-docs-git-react-native-sdk-pr1-beyondidentity.vercel.app/) to see rendered changes.