### PR TITLE
Update Add an application with a tip on creating inside a new realm

### DIFF
--- a/docs/how-to/add-an-application.mdx
+++ b/docs/how-to/add-an-application.mdx
@@ -40,7 +40,13 @@ You'll need to have a developer account, which comes with the **Beyond Identity 
 
 ## Admin Console
 
-An application can be created from the Beyond Identity Admin Console. 
+An application can be created from the Beyond Identity Admin Console.
+
+:::tip
+
+Most of the time you will want to create a new application in a realm other than your Beyond Identity Admin Realm.
+If you need guidance, visit **[Create a realm](/docs/next/create-realm)**.
+:::
 
 import AddAppAdminConsole  from '../includes/_add-application-console.mdx';
 

--- a/docs/how-to/add-an-application.mdx
+++ b/docs/how-to/add-an-application.mdx
@@ -44,8 +44,7 @@ An application can be created from the Beyond Identity Admin Console.
 
 :::tip
 
-Most of the time you will want to create a new application in a realm other than your Beyond Identity Admin Realm.
-If you need guidance, visit **[Create a realm](/docs/next/create-realm)**.
+Most of the time you will want to create a new application in a different realm other than your Beyond Identity Admin Realm. Applications created in the Beyond Identity Admin Realm default to the Client Credentials grant which is used for applications requesting access. Applications created in another realm default to the the Authorization Code grant which is used by users requesting access. If you need guidance, visit **[Create a realm](/docs/next/create-realm)**.
 :::
 
 import AddAppAdminConsole  from '../includes/_add-application-console.mdx';

--- a/docs/how-to/add-an-application.mdx
+++ b/docs/how-to/add-an-application.mdx
@@ -44,7 +44,7 @@ An application can be created from the Beyond Identity Admin Console.
 
 :::tip
 
-Most of the time you will want to create a new application in a different realm other than your Beyond Identity Admin Realm. Applications created in the Beyond Identity Admin Realm default to the Client Credentials grant which is used for applications requesting access. Applications created in another realm default to the the Authorization Code grant which is used by users requesting access. If you need guidance, visit **[Create a realm](/docs/next/create-realm)**.
+Most of the time you will want to create a new application in a different realm other than your Beyond Identity Admin Realm. Applications created in the Beyond Identity Admin Realm default to the Client Credentials grant which is used for applications requesting access outside of the context of a user. Applications created in another realm default to the Authorization Code grant which is used by users requesting access. If you need guidance, visit **[Create a realm](/docs/next/create-realm)**.
 :::
 
 import AddAppAdminConsole  from '../includes/_add-application-console.mdx';


### PR DESCRIPTION
Most of the time developer will want to create a new application in a realm other than the admin realm. A common mistake is to create one in the admin realm and then their auth doesn't work.
