### PR TITLE
Fix nav titles to have cursor pointer

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -530,7 +530,7 @@ nav[class^="menu"] {
   letter-spacing: 0.01786em;
 
   color: var(--ifm-font-color-base);
-  cursor: default;
+  cursor: pointer;
 }
 .theme-doc-sidebar-item-category-level-1 > .menu__list {
   padding-left: 12px;


### PR DESCRIPTION
Currently the mouse on hover doesn't change for titles in the nav bar. So it doesn't look like the content can be tapped into. This MR changes the cursor style. 