### PR TITLE
Publish v1.7.0 of the API OpenAPI specification

### DIFF
--- a/static/api/v1/openapi.yaml
+++ b/static/api/v1/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Beyond Identity API
-  version: 1.6.1
+  version: 1.7.0
   contact:
     email: support@beyondidentity.com
   description: |
@@ -4803,6 +4803,8 @@ paths:
                     display_name: Pet Authenticator Configuration
                     config:
                       type: hosted_web
+                      authentication_methods:
+                        - subtle_crypto_passkey
                       trusted_origins:
                         - 'http://localhost:8092'
         '400':
@@ -5424,7 +5426,15 @@ paths:
         - Resource Servers
       summary: Patch a Resource Server
       description: |
-        To update only specific attributes of an existing resource server, send a a PATCH request to `/v1/tenants/$TENANT_ID/realms/$REALM_ID/resource-servers/$RESOURCE_SERVER_ID`. Values in the request body for immutable or read-only fields will be ignored. Fields that are omitted from the request body will be left unchanged.
+        To update only specific attributes of an existing resource server, send a a
+        PATCH request to
+        `/v1/tenants/$TENANT_ID/realms/$REALM_ID/resource-servers/$RESOURCE_SERVER_ID`.
+        Values in the request body for immutable or read-only fields will be
+        ignored. Fields that are omitted from the request body will be left
+        unchanged.
+
+        Scopes that are removed from a resource server will be asynchronously
+        removed from all roles associated with the resource server.
       security:
         - BearerAuth:
             - 'resource-servers:update'
@@ -6552,6 +6562,7 @@ components:
           enum:
             - JWT
             - WEBAUTHN
+            - FIDO2
           description: |
             A string representing the type of certificate signing request that
             created this credential.
@@ -6560,6 +6571,9 @@ components:
 
             The value `WEBAUTHN` indicates that the CSR was delivered in the form of a
             WebAuthn attestation response.
+
+            `FIDO2` indicates that `raw` contains a FIDO2 WebAuthn (Level 2 at the
+            time of writing) attestation response object.
           readOnly: true
           example: JWT
         jwk_json:
@@ -6886,16 +6900,16 @@ components:
         - plain
         - s256
       description: |
-        PKCE code challenge methods supported for applications, as defined by 
+        PKCE code challenge methods supported for applications, as defined by
         [RFC-7636](https://datatracker.ietf.org/doc/html/rfc7636). Allowable values are:
-          - `disabled` : PKCE is disabled for this application. This is the default state if 
+          - `disabled` : PKCE is disabled for this application. This is the default state if
             the `pkce` field is left blank. Please note that public OIDC and OAuth2 configured
-            applications MUST enable PKCE support. Confidential clients can leave PKCE disabled 
-            if they choose. 
-          - `plain` : PKCE is enabled for this application. The server will correlate the `code_challenge` and 
+            applications MUST enable PKCE support. Confidential clients can leave PKCE disabled
+            if they choose.
+          - `plain` : PKCE is enabled for this application. The server will correlate the `code_challenge` and
             `code_verifier` between the `authorize` and `token` requests. In this configuration, those fields are
             required to be identical. This is the lower security option for PKCE support and should only be used
-            by legacy clients, or clients that don't support `s256`. 
+            by legacy clients, or clients that don't support `s256`.
           - `s256` : PKCE is enabled for this application, and the server will correlate the `code_challenge` and
             `code_verifier` between the `authorize` and `token` requests. In this configuration, those fields are
             required to equate as follows: `code_challenge` = `base64url(sha256(ascii(code_verifier)))`. This is
@@ -7117,17 +7131,6 @@ components:
           description: |
             An object specifying the settings for the supported authenticator type.
           oneOf:
-            - title: Web Authenticator
-              description: |
-                Configuration options for the hosted web authenticator. This authenticator is maintained by Beyond Identity and requires no additional configuration from the caller.
-              type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - hosted_web
             - title: Embedded SDK Authenticator
               description: Configuration options for the embedded SDK authenticator.
               type: object
@@ -7136,33 +7139,90 @@ components:
                 - invoke_url
                 - trusted_origins
               properties:
-                type:
-                  type: string
-                  enum:
-                    - embedded
-                invoke_url:
-                  type: string
-                  description: URL to invoke during the authentication flow.
-                  example: 'http://localhost:8092'
                 invocation_type:
-                  type: string
+                  default: automatic
+                  description: |
+                    The method used to invoke the `invoke_url` in the embedded authenticator
+                    config type. The two methods available are:
+
+                    The value `automatic` indicates that this invocation type automatically
+                    redirects you to your native or web app using the Invoke URL with a
+                    challenge that your app will need to sign.
+
+                    The value `manual` indicates that this invocation type will cause the
+                    challenge to be returned to you as part of a JSON response. It will then
+                    be up to you to get it to your native/web app any way you see fit. This is
+                    useful for flows where you require a lot more control when redirecting to
+                    your native/web app. Since the challenge is packaged as part of a URL,
+                    following the URL will result in the same behavior as if an Invocation
+                    Type of "automatic" were selected.
                   enum:
                     - automatic
                     - manual
-                  default: automatic
-                  description: |
-                    The method used to invoke the `invoke_url` in the embedded authenticator config type. The two methods available are:
-                      - automatic: This invocation type automatically redirects you to your
-                    native or web app using the Invoke URL with a challenge that your app will need to sign.
-                      - manual: This invocation type will cause the challenge to be returned
-                    to you as part of a JSON response. It will then be up to you to get it to your native/web app any way you see fit. This is useful for flows where you require a lot more control when redirecting to your native/web app. Since the challenge is packaged as part of a URL, following the URL will result in the same behavior as if an Invocation Type of "automatic" were selected.
+                  type: string
+                invoke_url:
+                  description: URL to invoke during the authentication flow.
+                  example: 'http://localhost:8092'
+                  type: string
                 trusted_origins:
-                  type: array
-                  items:
-                    type: string
-                    example: 'http://localhost:8092'
                   description: |
                     Trusted origins are URLs that will be allowed to make requests from a browser to the Beyond Identity API. This is used with Cross-Origin Resource Sharing (CORS). These may be in the form of `<scheme> "://" <host> [ ":" <port> ]`, such as `https://auth.your-domain.com` or `http://localhost:3000`.
+                  items:
+                    example: 'http://localhost:8092'
+                    type: string
+                  type: array
+                type:
+                  enum:
+                    - embedded
+                  type: string
+            - title: Hosted Web Authenticator
+              description: |
+                Configuration options for the hosted web experience. This authenticator is maintained by Beyond Identity and allows the caller to customize authentication methods.
+              type: object
+              required:
+                - type
+                - authentication_methods
+                - trusted_origins
+              properties:
+                authentication_methods:
+                  items:
+                    properties:
+                      type:
+                        description: |
+                          Within our hosted web product, an array of values determines the
+                          client-side authentication workflows:
+
+                          The value `webauthn_passkey` triggers a workflow that generates a hardware
+                          key within your device's trusted execution environment (TEE). If webauthn
+                          passkeys are not supported in the browser, specifying one of the other two
+                          authentication methods will result in a fallback to that mechanism.
+
+                          The value `software_passkey` activates a workflow where a passkey is
+                          securely created within the browser's context.
+
+                          The value `email_one_time_password` enables a workflow that verifies
+                          identity via an email one-time password.
+                        enum:
+                          - email_one_time_password
+                          - software_passkey
+                          - webauthn_passkey
+                        type: string
+                    required:
+                      - type
+                    title: AuthenticationMethod
+                    type: object
+                  type: array
+                trusted_origins:
+                  description: |
+                    Trusted origins are URLs that will be allowed to make requests from a browser to the Beyond Identity API. This is used with Cross-Origin Resource Sharing (CORS). These may be in the form of `<scheme> "://" <host> [ ":" <port> ]`, such as `https://auth.your-domain.com` or `http://localhost:3000`.
+                  items:
+                    example: 'http://localhost:8092'
+                    type: string
+                  type: array
+                type:
+                  enum:
+                    - hosted_web
+                  type: string
     ListApplicationsResponse:
       title: List Applications Response
       description: Response for ListApplications.


### PR DESCRIPTION
### Your checklist for this pull request

Thank you for your contribution to the `next-dev-docs` repo. 

🚨Please review the [Pull request guidelines](../contributor-guide/contributor-guide.md#pull-request-guidelines) to this repository before submitting this PR.

- [X] Your code builds clean without any errors or warnings
  
  ```bash
  yarn build
  ```

- [X] You are using approved terminology

  Refer to the [style guide](../contributor-guide/style-guide.md) for help.


### Description 

Publish v1.7.0 of the v1 API OpenAPI specification.  This version documents the following changes:
```
- Support asynchronous deletion of role scopes for resource server
  updates.

- Add `FIDO2` as an enum to `csr_type` on the Credential resource.

- Reintroduce `hosted_web` as a type of authenticator config.
```